### PR TITLE
Adding "copytruncate" to avoid file deletion

### DIFF
--- a/gnocchi.logrotate
+++ b/gnocchi.logrotate
@@ -7,4 +7,5 @@ compress
     missingok
     compress
     minsize 100k
+    copytruncate
 }


### PR DESCRIPTION
Log files remain open after being rotated and you can see them "deleted" in lsof